### PR TITLE
remove registry name from image name

### DIFF
--- a/container-check
+++ b/container-check
@@ -146,8 +146,7 @@ def get_container_list(container_file):
         container_list = []
         for image_info in data:
             print('image_info: %s' % image_info)
-            container_list.append('%s/%s' % (image_info['push_destination'],
-                                             image_info['imagename']))
+            container_list.append(image_info['imagename'])
         return container_list
 
 


### PR DESCRIPTION
latest upstream changes hardcoded registry name in the image name. To
handle images in undercloud registry correctly again, we need to remove
the default hardcoded registry name