### PR TITLE
Do not explode on empty containers list

### DIFF
--- a/container-check
+++ b/container-check
@@ -174,15 +174,13 @@ def get_available_rpms():
 
 
 def get_container_list(container_file):
+    container_list = []
     with open(container_file) as cf:
-        data = yaml.safe_load(cf.read()).get('container_images')
-        if not data:
-            return None
-        container_list = []
+        data = yaml.safe_load(cf.read()).get('container_images', [])
         for image_info in data:
             print('image_info: %s' % image_info)
             container_list.append(image_info['imagename'])
-        return container_list
+    return container_list
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In the case the containers list was empty or non existent,
container-check would explode and produce a traceback. This is for
example visible at [1].

This commit makes container-check more robust about the input data.

[1] http://logs.openstack.org/06/572806/1/experimental/tripleo-ci-centos-7-scenario009-multinode-oooq/a88c395/logs/undercloud/home/zuul/overcloud_prep_containers.log.txt.gz