### PR TITLE
Fix yum_update_container args

### DIFF
--- a/container-check
+++ b/container-check
@@ -83,7 +83,8 @@ def populate_container_rpms_list(container):
     return (subproc.returncode, container, rpms)
 
 
-def yum_update_container(container, name, packages):
+def yum_update_container(args):
+    (container, name, packages) = args
 
     container_name = 'yum-update-%s' % name
 


### PR DESCRIPTION
6a116845a4be0319e27dd2910ca49f4627f227ef dropped the set notation
however this function is called using a multiprocess map which passes in
multiple params. We need to fix the function definition to work
correctly.

Related-Bug: LP#1931134